### PR TITLE
Refactor: Allow single username or wordlist for brute-force modules

### DIFF
--- a/core/brute.py
+++ b/core/brute.py
@@ -37,61 +37,90 @@ def run_ftp_bruteforce():
         except ValueError:
             print("[❌] Invalid port number.")
 
-    while True:
-        userlist_path = input("Path to username wordlist (e.g. wordlists/users.txt): ").strip()
-        if not userlist_path:
-            print("[❌] Username wordlist path cannot be empty.")
-        elif not os.path.exists(userlist_path):
-            print(f"[❌] Username wordlist file not found: {userlist_path}")
-        else:
-            break
+    usernames = []
+    userlist_path_for_report = "N/A (Single Username)" # For reporting
 
     while True:
-        passlist_path = input("Path to password wordlist (e.g. wordlists/passwords.txt): ").strip()
-        if not passlist_path:
+        know_username = input("Do you know a specific username? (y/n, default n): ").strip().lower()
+        if know_username == 'y':
+            single_username = input("Enter the username: ").strip()
+            if not single_username:
+                print("[❌] Username cannot be empty.")
+                continue
+            usernames = [single_username]
+            break
+        else: # 'n' or anything else, proceed to ask for wordlist
+            userlist_path_input = input("Path to username wordlist (e.g. wordlists/users.txt): ").strip()
+            if not userlist_path_input:
+                print("[❌] Username wordlist path cannot be empty.")
+                continue # Re-ask "know_username" or path. Here, re-asks "know_username".
+            elif not os.path.exists(userlist_path_input):
+                print(f"[❌] Username wordlist file not found: {userlist_path_input}")
+                continue
+            else:
+                try:
+                    with open(userlist_path_input, 'r', encoding='utf-8', errors='ignore') as ufile:
+                        loaded_usernames = [u.strip() for u in ufile if u.strip()]
+                    if not loaded_usernames:
+                        print(f"[❌] Username wordlist '{userlist_path_input}' is empty.")
+                        continue
+                    usernames = loaded_usernames
+                    userlist_path_for_report = userlist_path_input # Save for reporting
+                    break
+                except Exception as e:
+                    print(f"[❌] Error reading username wordlist: {e}")
+                    continue # Re-ask "know_username"
+
+    passwords = []
+    passlist_path = "" # Initialize for use in reporting
+    while True:
+        passlist_path_input = input("Path to password wordlist (e.g. wordlists/passwords.txt): ").strip()
+        if not passlist_path_input:
             print("[❌] Password wordlist path cannot be empty.")
-        elif not os.path.exists(passlist_path):
-            print(f"[❌] Password wordlist file not found: {passlist_path}")
+            continue
+        elif not os.path.exists(passlist_path_input):
+            print(f"[❌] Password wordlist file not found: {passlist_path_input}")
+            continue
         else:
-            break
+            try:
+                with open(passlist_path_input, 'r', encoding='utf-8', errors='ignore') as pfile:
+                    loaded_passwords = [p.strip() for p in pfile if p.strip()]
+                if not loaded_passwords:
+                    print(f"[❌] Password wordlist '{passlist_path_input}' is empty.")
+                    continue
+                passwords = loaded_passwords
+                passlist_path = passlist_path_input # Save for reporting
+                break
+            except Exception as e:
+                print(f"[❌] Error reading password wordlist: {e}")
+                continue
 
-    # The os.path.exists checks are handled in the input loops above.
+    # Wordlists (usernames and passwords) are now loaded and validated.
 
-    try:
-        with open(userlist_path, 'r', encoding='utf-8', errors='ignore') as ufile:
-         usernames = [u.strip() for u in ufile if u.strip()]
-        with open(passlist_path, 'r', encoding='utf-8', errors='ignore') as pfile:
-         passwords = [p.strip() for p in pfile if p.strip()]
-    except Exception as e:
-        print(f"[❌] Error reading files: {e}")
-        input("Press Enter to return...")
-        return
-
-
-    print(f"\n[🔍] Starting brute-force on {target}:{port}...\n")
+    print(f"\n[🔍] Starting FTP brute-force on {target}:{port} with {len(usernames)} username(s) and {len(passwords)} password(s)...\n")
     start_time = time.time()
     found_credentials = None
 
     try:
-        for username in usernames:
+        for current_username in usernames: # Iterate over the (potentially single) username
             for password in passwords:
                 try:
                     ftp = ftplib.FTP()
                     ftp.connect(target, port, timeout=3)
-                    ftp.login(username, password)
-                    print(f"[✅] SUCCESS: {username}:{password}")
+                    ftp.login(current_username, password)
+                    print(f"[✅] SUCCESS: {current_username}:{password}")
                     ftp.quit()
-                    found_credentials = f"{username}:{password}"
-                    # Break out of both loops if credentials are found
-                    raise StopIteration
+                    found_credentials = f"{current_username}:{password}"
+                    raise StopIteration # Signal to break from both loops
                 except ftplib.error_perm:
-                    print(f"[❌] Failed: {username}:{password}")
+                    print(f"[❌] Failed: {current_username}:{password}")
                 except Exception as e:
                     print(f"[⚠️ ] Error: {e}")
-                    # Decide if you want to break the inner loop or continue
-                    # For now, let's break the inner loop on other errors
-                    break
-            if found_credentials: # If found in inner loop, break outer
+                    # For FTP, an error during login might mean the user/pass is wrong,
+                    # or a connection issue. Continuing to next password might be okay,
+                    # but for simplicity breaking inner loop on general errors.
+                    break # Break from password loop for this username
+            if found_credentials: # If found in inner loop, break outer username loop
                 break
     except StopIteration: # Custom signal to break from nested loops
         pass
@@ -103,9 +132,14 @@ def run_ftp_bruteforce():
             f"Target: {target}:{port}",
             f"Service: FTP",
             f"Scan Duration: {duration} seconds",
-            f"Username Wordlist: {userlist_path}",
-            f"Password Wordlist: {passlist_path}",
         ]
+        if len(usernames) == 1 and userlist_path_for_report == "N/A (Single Username)":
+            report_lines.append(f"Username: {usernames[0]}")
+        else:
+            report_lines.append(f"Username Wordlist: {userlist_path_for_report}")
+
+        report_lines.append(f"Password Wordlist: {passlist_path}") # This was correctly assigned
+
         if found_credentials:
             report_lines.append(f"Outcome: Credentials Found")
             report_lines.append(f"Credentials: {found_credentials}")
@@ -123,7 +157,8 @@ from tqdm import tqdm  # install with: pip install tqdm
 
 def run_ssh_bruteforce():
     clear()
-    print("\n🔐 [SSH Brute-Force] (Single Username Mode)")
+    # Description will be updated in a later step in the plan.
+    print("\n🔐 [SSH Brute-Force]")
 
     while True:
         target = input("Enter SSH IP or domain: ").strip()
@@ -146,93 +181,156 @@ def run_ssh_bruteforce():
         except ValueError:
             print("[❌] Invalid port number.")
 
-    while True:
-        username = input("Enter known username: ").strip()
-        if not username:
-            print("[❌] Username cannot be empty.")
-        else:
-            break
+    usernames = []
+    userlist_path_for_report = "N/A (Single Username)"
 
     while True:
-        passlist_path = input("Path to password wordlist: ").strip()
-        if not passlist_path:
+        know_username = input("Do you know a specific username? (y/n, default n): ").strip().lower()
+        if know_username == 'y':
+            single_username = input("Enter the username: ").strip()
+            if not single_username:
+                print("[❌] Username cannot be empty.")
+                continue
+            usernames = [single_username]
+            break
+        else: # 'n' or anything else, proceed to ask for wordlist
+            userlist_path_input = input("Path to username wordlist (e.g. wordlists/users.txt): ").strip()
+            if not userlist_path_input:
+                print("[❌] Username wordlist path cannot be empty.")
+                continue
+            elif not os.path.exists(userlist_path_input):
+                print(f"[❌] Username wordlist file not found: {userlist_path_input}")
+                continue
+            else:
+                try:
+                    with open(userlist_path_input, 'r', encoding='utf-8', errors='ignore') as ufile:
+                        loaded_usernames = [u.strip() for u in ufile if u.strip()]
+                    if not loaded_usernames:
+                        print(f"[❌] Username wordlist '{userlist_path_input}' is empty.")
+                        continue
+                    usernames = loaded_usernames
+                    userlist_path_for_report = userlist_path_input
+                    break
+                except Exception as e:
+                    print(f"[❌] Error reading username wordlist: {e}")
+                    continue
+
+    passwords = []
+    passlist_path = "" # Initialize for use in reporting
+    while True:
+        passlist_path_input = input("Path to password wordlist: ").strip()
+        if not passlist_path_input:
             print("[❌] Password wordlist path cannot be empty.")
-        elif not os.path.exists(passlist_path):
-            print(f"[❌] Password wordlist file not found: {passlist_path}")
+            continue
+        elif not os.path.exists(passlist_path_input):
+            print(f"[❌] Password wordlist file not found: {passlist_path_input}")
+            continue
         else:
-            break
+            try:
+                with open(passlist_path_input, "r", encoding="utf-8", errors="ignore") as f:
+                    loaded_passwords = [line.strip() for line in f if line.strip()]
+                if not loaded_passwords:
+                    print(f"[❌] Password wordlist '{passlist_path_input}' is empty.")
+                    continue
+                passwords = loaded_passwords
+                passlist_path = passlist_path_input
+                break
+            except Exception as e:
+                print(f"[❌] Error reading password wordlist: {e}")
+                continue
 
-    # The os.path.exists check is handled in the input loop above.
-
-    try:
-        with open(passlist_path, "r", encoding="utf-8", errors="ignore") as f:
-            passwords = [line.strip() for line in f if line.strip()]
-    except Exception as e:
-        print(f"[❌] Error reading wordlist: {e}")
-        input("Press Enter to return...")
-        return
-
-    print(f"\n[🔍] Brute-forcing {target}:{port} with user '{username}' ({len(passwords):,} passwords)\n")
+    print(f"\n[🔍] Starting SSH brute-force on {target}:{port} with {len(usernames)} username(s) and {len(passwords)} password(s)...\n")
 
     client = paramiko.SSHClient()
     client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     start_time = time.time()
-    found_password = None
+    found_credentials_ssh = None # Renamed to avoid conflict with other functions' variable
 
     try:
-        for password in tqdm(passwords, desc="Trying passwords", unit="pw"):
-            try:
-                client.connect(
-                    hostname=target,
-                    port=port,
-                    username=username,
-                    password=password,
-                    timeout=5,
-                    auth_timeout=5,
-                    banner_timeout=5,
-                    allow_agent=False,
-                    look_for_keys=False
-                )
-                tqdm.write(f"\n[✅] SUCCESS! Credentials: {username}:{password}")
-                found_password = password
-                client.close()
-                break  # Exit loop once password is found
-            except paramiko.AuthenticationException:
-                pass  # invalid login, ignore
-            except paramiko.SSHException as e:
-                tqdm.write(f"[⚠️ ] SSH error or rate-limiting detected: {e}")
-                time.sleep(random.uniform(5, 10)) # Wait a bit if SSH server is unhappy
-            except Exception as e:
-                tqdm.write(f"[❌] Unexpected error: {e}")
-            finally:
-                # Ensure client is closed if it was opened and an error occurred mid-connection attempt
-                # However, client.connect() might not always initialize the transport if it fails early.
-                if client._transport and client._transport.is_active():
+        for current_username in tqdm(usernames, desc="Usernames", unit="user", leave=len(usernames)>1):
+            # Only show password progress bar if there's one username, otherwise it's too noisy.
+            password_iterator = tqdm(passwords, desc=f"Trying passwords for {current_username}", unit="pw", leave=False) if len(usernames) == 1 else passwords
+            for password in password_iterator:
+                try:
+                    # Ensure client is freshly connected for each attempt if not already connected
+                    # or if previous attempt failed in a way that closed it.
+                    # For simplicity, we'll attempt to connect each time.
+                    # More advanced logic could reuse connections if appropriate for the server.
+                    if client._transport and client._transport.is_active():
+                        client.close() # Close previous connection if any
+
+                    client.connect(
+                        hostname=target,
+                        port=port,
+                        username=current_username,
+                        password=password,
+                        timeout=5,
+                        auth_timeout=5,
+                        banner_timeout=5,
+                        allow_agent=False,
+                        look_for_keys=False
+                    )
+                    tqdm.write(f"\n[✅] SUCCESS! Credentials: {current_username}:{password}")
+                    found_credentials_ssh = f"{current_username}:{password}"
                     client.close()
+                    raise StopIteration # Signal to break all loops
+                except paramiko.AuthenticationException:
+                    if len(usernames) > 1 and isinstance(password_iterator, type(passwords)): # only print if not using tqdm for passwords
+                        tqdm.write(f"[❌] Failed: {current_username}:{password}")
+                    # If using tqdm for passwords (single user), failed attempts are implicitly shown by progress.
+                    pass  # invalid login, ignore
+                except paramiko.SSHException as e:
+                    tqdm.write(f"[⚠️ ] SSH error for {current_username}:{password}. Server busy or config issue: {e}")
+                    time.sleep(random.uniform(5, 10)) # Wait a bit
+                    # Depending on the error, may want to break inner or outer loop
+                    # For now, break password loop for this user if SSH error occurs
+                    break
+                except Exception as e:
+                    tqdm.write(f"[❌] Unexpected error for {current_username}:{password}: {e}")
+                    break # Break password loop for this user
+                finally:
+                    if client._transport and client._transport.is_active():
+                        client.close()
+            if found_credentials_ssh:
+                break # Break username loop
+    except StopIteration: # Handles breaking from nested loops
+        pass
     finally:
+        # Ensure client is closed if loops exited unexpectedly or after completion
+        if client._transport and client._transport.is_active():
+            client.close()
+
         end_time = time.time()
         duration = round(end_time - start_time, 2)
 
         report_lines = [
             f"Target: {target}:{port}",
             f"Service: SSH",
-            f"Username: {username}",
-            f"Password Wordlist: {passlist_path}",
             f"Scan Duration: {duration} seconds",
         ]
 
-        if found_password:
-            report_lines.append(f"Outcome: Password Found")
-            report_lines.append(f"Credentials: {username}:{found_password}")
+        if len(usernames) == 1 and userlist_path_for_report == "N/A (Single Username)":
+            report_lines.append(f"Username: {usernames[0]}")
+        else:
+            report_lines.append(f"Username Wordlist: {userlist_path_for_report}")
+
+        report_lines.append(f"Password Wordlist: {passlist_path}")
+
+        if found_credentials_ssh:
+            report_lines.append(f"Outcome: Credentials Found")
+            report_lines.append(f"Credentials: {found_credentials_ssh}")
             status_message = "[✅] Credentials found and reported."
         else:
-            report_lines.append(f"Outcome: No Password Found")
-            status_message = "[❌] No valid password found. Report generated."
+            report_lines.append(f"Outcome: No Credentials Found")
+            status_message = "[❌] No valid credentials found. Report generated."
             # This print was originally after the loop, moving it here to be part of the final status
-            print("\n[❌] No valid password found.")
+            # Only print if no creds found and not aborted by other error (e.g. connection error)
+            if not found_credentials_ssh: # Check if we should print this
+                 tqdm.write("\n[❌] No valid credentials found across all attempts.")
+
 
         write_html_section("SSH Brute-Force Results", report_lines)
-        print(f"[💾] {status_message} Appended to report.html")
+        print(f"\n[💾] {status_message} Appended to report.html")
         input("Press Enter to return...")
 
 
@@ -250,71 +348,110 @@ def run_http_bruteforce():
         else:
             break
 
-    while True:
-        userlist_path = input("Path to username wordlist (e.g. wordlists/users.txt): ").strip()
-        if not userlist_path:
-            print("[❌] Username wordlist path cannot be empty.")
-        elif not os.path.exists(userlist_path):
-            print(f"[❌] Username wordlist file not found: {userlist_path}")
-        else:
-            break
+    usernames = []
+    userlist_path_for_report = "N/A (Single Username)"
 
     while True:
-        passlist_path = input("Path to password wordlist (e.g. wordlists/passwords.txt): ").strip()
-        if not passlist_path:
+        know_username = input("Do you know a specific username? (y/n, default n): ").strip().lower()
+        if know_username == 'y':
+            single_username = input("Enter the username: ").strip()
+            if not single_username:
+                print("[❌] Username cannot be empty.")
+                continue
+            usernames = [single_username]
+            break
+        else: # 'n' or anything else, proceed to ask for wordlist
+            userlist_path_input = input("Path to username wordlist (e.g. wordlists/users.txt): ").strip()
+            if not userlist_path_input:
+                print("[❌] Username wordlist path cannot be empty.")
+                continue
+            elif not os.path.exists(userlist_path_input):
+                print(f"[❌] Username wordlist file not found: {userlist_path_input}")
+                continue
+            else:
+                try:
+                    with open(userlist_path_input, 'r', encoding='utf-8', errors='ignore') as ufile:
+                        loaded_usernames = [u.strip() for u in ufile if u.strip()]
+                    if not loaded_usernames:
+                        print(f"[❌] Username wordlist '{userlist_path_input}' is empty.")
+                        continue
+                    usernames = loaded_usernames
+                    userlist_path_for_report = userlist_path_input
+                    break
+                except Exception as e:
+                    print(f"[❌] Error reading username wordlist: {e}")
+                    continue
+
+    passwords = []
+    passlist_path = "" # Initialize for use in reporting
+    while True:
+        passlist_path_input = input("Path to password wordlist (e.g. wordlists/passwords.txt): ").strip()
+        if not passlist_path_input:
             print("[❌] Password wordlist path cannot be empty.")
-        elif not os.path.exists(passlist_path):
-            print(f"[❌] Password wordlist file not found: {passlist_path}")
+            continue
+        elif not os.path.exists(passlist_path_input):
+            print(f"[❌] Password wordlist file not found: {passlist_path_input}")
+            continue
         else:
-            break
+            try:
+                with open(passlist_path_input, 'r', encoding='utf-8', errors='ignore') as pfile:
+                    loaded_passwords = [p.strip() for p in pfile if p.strip()]
+                if not loaded_passwords:
+                    print(f"[❌] Password wordlist '{passlist_path_input}' is empty.")
+                    continue
+                passwords = loaded_passwords
+                passlist_path = passlist_path_input
+                break
+            except Exception as e:
+                print(f"[❌] Error reading password wordlist: {e}")
+                continue
 
-    # The os.path.exists checks are handled in the input loops above.
-
-    try:
-        with open(userlist_path, 'r', encoding='utf-8', errors='ignore') as ufile:
-            usernames = [u.strip() for u in ufile if u.strip()]
-        with open(passlist_path, 'r', encoding='utf-8', errors='ignore') as pfile:
-            passwords = [p.strip() for p in pfile if p.strip()]
-    except Exception as e:
-        print(f"[❌] Error reading files: {e}")
+    if not usernames or not passwords: # Should not happen if loops above work correctly
+        print("[❌] Usernames or passwords list is empty. This should be caught earlier.")
         input("Press Enter to return...")
         return
 
-    if not usernames or not passwords:
-        print("[❌] Wordlists cannot be empty.")
-        input("Press Enter to return...")
-        return
-
-    print(f"\n[🔍] Starting HTTP Basic Auth brute-force on {target_url}...\n")
+    print(f"\n[🔍] Starting HTTP Basic Auth brute-force on {target_url} with {len(usernames)} username(s) and {len(passwords)} password(s)...\n")
     start_time = time.time()
     found_credentials = None
     connection_error_occurred = False
 
     try:
-        for username in tqdm(usernames, desc="Usernames", unit="user"):
-            for password in tqdm(passwords, desc="Passwords", unit="pass", leave=False):
+        # Adjust tqdm behavior based on number of usernames
+        username_iterator = tqdm(usernames, desc="Usernames", unit="user", leave=len(usernames)>1) if len(usernames) > 1 else usernames
+
+        for current_username in username_iterator:
+            # Show password progress bar only if there's one username
+            password_iterator = tqdm(passwords, desc=f"Passwords for {current_username}", unit="pass", leave=False) if len(usernames) == 1 else passwords
+
+            for password in password_iterator:
                 try:
-                    response = requests.get(target_url, auth=HTTPBasicAuth(username, password), timeout=5)
+                    response = requests.get(target_url, auth=HTTPBasicAuth(current_username, password), timeout=5)
 
                     if response.status_code == 200:
-                        tqdm.write(f"\n[✅] SUCCESS: {username}:{password} (Status: {response.status_code})")
-                        found_credentials = f"{username}:{password}"
+                        tqdm.write(f"\n[✅] SUCCESS: {current_username}:{password} (Status: {response.status_code})")
+                        found_credentials = f"{current_username}:{password}"
                         raise StopIteration # Signal to break from loops
                     elif response.status_code == 401:
-                        tqdm.write(f"[❌] Failed: {username}:{password} (Status: {response.status_code} Unauthorized)")
+                        if len(usernames) > 1 or not isinstance(password_iterator, tqdm): # Print if not using detailed password tqdm
+                           tqdm.write(f"[❌] Failed: {current_username}:{password} (Status: {response.status_code} Unauthorized)")
+                        # else: tqdm implies failure for single user
                     elif response.status_code == 403:
-                        tqdm.write(f"[❌] Failed: {username}:{password} (Status: {response.status_code} Forbidden)")
+                        tqdm.write(f"[❌] Failed: {current_username}:{password} (Status: {response.status_code} Forbidden) - This might indicate IP ban or WAF block.")
+                        # Consider breaking more loops if 403 is persistent
                     else:
-                        tqdm.write(f"[⚠️ ] Info: {username}:{password} (Status: {response.status_code})")
+                        tqdm.write(f"[⚠️ ] Info: {current_username}:{password} (Status: {response.status_code})")
 
                 except requests.exceptions.ConnectionError:
                     tqdm.write(f"[❌] Error: Could not connect to {target_url}. Check URL and connection.")
                     connection_error_occurred = True
                     raise StopIteration # Signal to break from loops and go to finally
                 except requests.exceptions.Timeout:
-                    tqdm.write(f"[⚠️ ] Timeout for {username}:{password}. Server might be slow or rate-limiting.")
+                    tqdm.write(f"[⚠️ ] Timeout for {current_username}:{password}. Server might be slow or rate-limiting.")
                 except requests.exceptions.RequestException as e:
-                    tqdm.write(f"[❌] Request error for {username}:{password}: {e}")
+                    tqdm.write(f"[❌] Request error for {current_username}:{password}: {e}")
+                    # Depending on the error, might want to break
+                    break # Break password loop for this user on other request errors
 
                 if found_credentials or connection_error_occurred:
                     break # Break inner password loop
@@ -334,9 +471,14 @@ def run_http_bruteforce():
             f"Target URL: {target_url}",
             f"Service: HTTP Basic Auth",
             f"Scan Duration: {duration} seconds",
-            f"Username Wordlist: {userlist_path}",
-            f"Password Wordlist: {passlist_path}",
         ]
+        if len(usernames) == 1 and userlist_path_for_report == "N/A (Single Username)":
+            report_lines.append(f"Username: {usernames[0]}")
+        else:
+            report_lines.append(f"Username Wordlist: {userlist_path_for_report}")
+
+        report_lines.append(f"Password Wordlist: {passlist_path}")
+
 
         if connection_error_occurred:
             report_lines.append("Outcome: Connection Error")
@@ -349,7 +491,8 @@ def run_http_bruteforce():
         else:
             report_lines.append("Outcome: No Credentials Found")
             status_message = "[❌] No valid credentials found. Report generated."
-            print("\n[❌] No valid credentials found.")
+            if not connection_error_occurred: # Only print if not a connection error
+                tqdm.write("\n[❌] No valid credentials found.")
 
 
         write_html_section("HTTP Basic Auth Brute-Force Results", report_lines)


### PR DESCRIPTION
Modified the FTP, SSH, and HTTP Basic Auth brute-force functions to give the user the option to provide either a single known username or a path to a username wordlist.

Key changes:
- Updated input prompts and logic in `run_ftp_bruteforce`, `run_ssh_bruteforce`, and `run_http_bruteforce`.
- Ensured validation for username/password file paths and checks for empty wordlists.
- Adjusted `tqdm` progress bar display for better user experience when multiple usernames are processed.
- Updated the reporting sections to accurately reflect whether a single username or a username wordlist was utilized.
- Removed "(Single Username Mode)" from the SSH Brute-Force description in the main menu as it now supports username lists.